### PR TITLE
Missing optional variable db_name #1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ resource "aws_db_instance" "this" {
   publicly_accessible                 = var.publicly_accessible
   username                            = var.username
   vpc_security_group_ids              = var.vpc_security_group_ids
+  db_name                             = var.db_name
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -146,3 +146,9 @@ variable "role_name" {
   description = "Role name for enhanced monitoring"
   default     = null
 }
+
+variable "db_name" {
+  type        = string
+  description = "Initial database name"
+  default     = null
+}


### PR DESCRIPTION
## What
Add optional variable db_name

## Why
This was required by another project. In the other project, an initial database was required so that a database migration could take place. 